### PR TITLE
Pure POSIX sh version

### DIFF
--- a/mkvrg
+++ b/mkvrg
@@ -326,3 +326,5 @@ for file in "${files[@]}"; do
     [[ $tracksProcessed -gt 0 ]] && ((filesProcessed++))
 done
 [[ $filesProcessed -gt 0 ]] && cleantmp 0
+
+# vi: sw=4

--- a/mkvrg
+++ b/mkvrg
@@ -221,6 +221,16 @@ if [ ! -w "$tmpFile" ]; then
 fi
 # Create temporary file }}}
 
+#{{{ cleantmp ( )
+cleantmp ( ) {
+    exit_code=$?
+    [ -f "$muxInFile" ] && [ -f "$muxOutFile" ] && rm "$muxOutFile"
+    rm "$tmpFile"
+    exit $exit_code
+}
+#}}} cleantmp ( ) 
+trap cleantmp HUP INT QUIT TERM EXIT
+
 #{{{ Set reference loudness
 REFLOUDNESS=-23.00
 case "$FFMPEGFILTER" in
@@ -233,13 +243,6 @@ esac
 # Set reference loudness }}}
 
 VERIFY_CHECK="${REPLAYGAIN_ALGORITHM}: ${FFMPEGFILTER}"
-
-trap cleantmp HUP INT QUIT TERM
-cleantmp ( ) {
-    [ -f "$muxInFile" ] && [ -f "$muxOutFile" ] && rm "$muxOutFile"
-    rm "$tmpFile"
-    [ -n "$1" ] && exit "$1" || exit 1
-}
 
 lufsTodB ( ) {
     isnum "$1" || return 1
@@ -410,6 +413,6 @@ for file in $files; do
     done
     [ $tracksProcessed -gt 0 ] && filesProcessed=$(( filesProcessed + 1 ))
 done
-[ $filesProcessed -gt 0 ] && cleantmp 0
+[ $filesProcessed -gt 0 ]
 
 # vi: sw=4 sts=4 smarttab foldmethod=marker

--- a/mkvrg
+++ b/mkvrg
@@ -116,8 +116,7 @@ PREVIEW=${PREVIEW:-false}
 ################################### ENV VARS End ########################################
 #########################################################################################
 
-# for more convenient regex construction
-FLOAT_ERE='[+-]?[0-9]+\.[0-9]+'
+LC_NUMERIC=C
 
 log_message ( ) {
     level=$1
@@ -156,8 +155,11 @@ log_warn ( ) { log_message warn "$@"; }
 log_notice ( ) { log_message notice "$@"; }
 log_info ( ) { log_message info "$@"; }
 
+# for more convenient regex construction
+FLOAT_ERE='[+-]?[[:digit:]]*\.[[:digit:]]+'
+
 isint ( ) { match_ere '^[+-]?[[:digit:]]+$' "$1"; }
-isfloat ( ) { match_ere '^[+-]?[[:digit:]]*\.[[:digit:]]+$' "$1"; }
+isfloat ( ) { match_ere "^$FLOAT_ERE$" "$1"; }
 isnum ( ) { isint "$1" || isfloat "$1"; }
 
 cmd_exists ( ) { command -v "$1"; } >/dev/null 2>&1
@@ -201,14 +203,14 @@ if [ ! -w "$tmpFile" ]; then
     exit 7
 fi
 
-REFLOUDNESS="-23"
+REFLOUDNESS=-23.00
 case "$FFMPEGFILTER" in
     loudnorm)	REFLOUDNESS=-24.00 ;;
     replaygain)	REFLOUDNESS=-18.00 ;;
 esac
 
 [ "$FFMPEGFILTER" != "replaygain" ] &&
-    REFLOUDNESS=$(awk "BEGIN{printf \"%0.2f\", $REFLOUDNESS + $LOUDNESSOFFSET}")
+    REFLOUDNESS=$(awk "BEGIN{print $REFLOUDNESS + $LOUDNESSOFFSET}")
 
 VERIFY_CHECK="${REPLAYGAIN_ALGORITHM}: ${FFMPEGFILTER}"
 
@@ -221,7 +223,7 @@ cleantmp ( ) {
 
 lufsTodB ( ) {
     isnum "$1" || return 1
-    awk "BEGIN{printf \"%0.2f\", $REFLOUDNESS - $1}"
+    awk "BEGIN{print $REFLOUDNESS - $1}"
 }
 
 dBToLufs ( ) {
@@ -230,12 +232,12 @@ dBToLufs ( ) {
 
 dBtoAmplitude ( ) {
     isnum "$1" || return 1
-    printf "%06f" "$(awk "BEGIN{print 10^($1/20)}")"
+    awk "BEGIN{print 10^($1/20)}"
 }
 
 amplitudeToDB ( ) {
     isnum "$1" || return 1
-    printf "%0.2f" "$(awk "BEGIN{print 20*log($1)/log(10)}")"
+    awk "BEGIN{print 20*log($1)/log(10)}"
 }
 
 isMatroska ( ) {
@@ -307,23 +309,23 @@ for file in $files; do
             echo "$ffmpegCmd"
             ffmpegOut=$(eval "$ffmpegCmd" 2>&1 | tr "\n" " " | sed "s/^.*\(Parsed_ebur128.*$\)/\1/" | sed "s/ \+/ /g")
             echo "$ffmpegOut"
-            trackGain=$(lufsTodB "$(echo "$ffmpegOut" | grep -Po " I: $FLOAT_ERE LUFS" | cut -d\  -f3)")
-            trackPeak=$(dBtoAmplitude "$(echo "$ffmpegOut" | grep -Po " Peak: $FLOAT_ERE dBFS" | cut -d\  -f3)")
-            trackRange=$(printf "%0.2f" "$(echo "$ffmpegOut" | grep -Po " Loudness range: LRA: $FLOAT_ERE LU" | cut -d\  -f5)")
+            trackGain=$(lufsTodB "$(echo "$ffmpegOut" | grep -Eo " I: $FLOAT_ERE LUFS" | cut -d\  -f3)")
+            trackPeak=$(dBtoAmplitude "$(echo "$ffmpegOut" | grep -Eo " Peak: $FLOAT_ERE dBFS" | cut -d\  -f3)")
+            trackRange=$(echo "$ffmpegOut" | grep -Eo " Loudness range: LRA: $FLOAT_ERE LU" | cut -d\  -f5)
         elif [ "$FFMPEGFILTER" = "loudnorm" ]; then
             ffmpegCmd="${ffmpegCmd}loudnorm=print_format=summary\" -f null -"
             echo "$ffmpegCmd"
             ffmpegOut=$(eval "$ffmpegCmd" 2>&1 | tr "\n" " " | sed "s/^.*\(Parsed_loudnorm.*$\)/\1/" | sed "s/ \+/ /g")
             echo "$ffmpegOut"
-            trackGain=$(lufsTodB "$(echo "$ffmpegOut" | grep -Po "Input Integrated: $FLOAT_ERE LUFS" | cut -d\  -f3)")
-            trackPeak=$(dBtoAmplitude "$(echo "$ffmpegOut" | grep -Po "Input True Peak: $FLOAT_ERE dBTP" | cut -d\  -f4)")
-            trackRange=$(printf "%0.2f" "$(echo "$ffmpegOut" | grep -Po "Input LRA: $FLOAT_ERE LU" | cut -d\  -f3)")
+            trackGain=$(lufsTodB "$(echo "$ffmpegOut" | grep -Eo "Input Integrated: $FLOAT_ERE LUFS" | cut -d\  -f3)")
+            trackPeak=$(dBtoAmplitude "$(echo "$ffmpegOut" | grep -Eo "Input True Peak: $FLOAT_ERE dBTP" | cut -d\  -f4)")
+            trackRange=$(echo "$ffmpegOut" | grep -Eo "Input LRA: $FLOAT_ERE LU" | cut -d\  -f3)
         elif [ "$FFMPEGFILTER" = "replaygain" ]; then
             ffmpegCmd="${ffmpegCmd}replaygain\" -f null -"
             echo "$ffmpegCmd"
             ffmpegOut=$(eval "$ffmpegCmd" 2>&1 | sed "s/track_gain = -24.00 dB//" | sed "s/track_peak = 0.000000//")
-            trackGain=$(echo "$ffmpegOut" | grep -Po "track_gain = $FLOAT_ERE dB" | cut -d\  -f3 | sed "s/^+//")
-            trackPeak=$(echo "$ffmpegOut" | grep -Po "track_peak = $FLOAT_ERE" | cut -d\  -f3)
+            trackGain=$(echo "$ffmpegOut" | grep -Eo "track_gain = $FLOAT_ERE dB" | cut -d\  -f3 | sed "s/^+//")
+            trackPeak=$(echo "$ffmpegOut" | grep -Eo "track_peak = $FLOAT_ERE" | cut -d\  -f3)
         else
             exit 8
         fi
@@ -349,21 +351,21 @@ for file in $files; do
                     </Simple>
                     <Simple>
                         <Name>REPLAYGAIN_REFERENCE_LOUDNESS</Name>
-                        <String>$REFLOUDNESS LUFS</String>
+			<String>$(printf '%0.2f LUFS' "$REFLOUDNESS")</String>
                     </Simple>
                     <Simple>
                         <Name>REPLAYGAIN_TRACK_GAIN</Name>
-                        <String>$trackGain dB</String>
+			<String>$(printf '%0.2f dB' "$trackGain")</String>
                     </Simple>
                     <Simple>
                         <Name>REPLAYGAIN_TRACK_PEAK</Name>
-                        <String>$trackPeak</String>
+			<String>$(printf '%06f' "$trackPeak")</String>
                     </Simple>" > "$tmpFile"
         if [ "$trackRange" != "" ]; then
             echo "
                     <Simple>
                         <Name>REPLAYGAIN_TRACK_RANGE</Name>
-                        <String>$trackRange dB</String>
+			<String>$(printf '%06f dB' "$trackRange")</String>
                     </Simple>" >> "$tmpFile"
         fi
         echo "

--- a/mkvrg
+++ b/mkvrg
@@ -171,7 +171,7 @@ log_info ( ) {
 
 match_ere ( ) { # match string against extended reqex
     regex="$1" && shift
-    echo "$@" | grep -Eq "$regex"
+    echo "$*" | grep -Eq "$regex"
 }
 
 cmd_exists ( ) {
@@ -266,22 +266,29 @@ isMatroska ( ) {
 }
 
 filePos ( ) {
-    [[ ! $fileIter =~ ^[0-9]+$ ]] || [[ ! ${#files[@]} =~ ^[0-9]+$ ]] && return;
-    echo "(file $fileIter of ${#files[@]}, $(awk "BEGIN{print 100*($fileIter/${#files[@]})}")%)"
+    fileIter=$1
+    num_files=$2
+    ! isint "$fileIter" || ! isint "$num_files" && return 1;
+    echo "(file $fileIter of $num_files, $(awk "BEGIN{print 100*($fileIter/$num_files)}")%)"
 }
 
-if [[ $PREVIEW == false && $REMUX == true ]]; then
-    REGEX="$(echo "(^.*)\.(asf|avi|flv|m4[pv]|mp[4g]|mov|mpeg|m2?ts|ogv|qt|ts|vob|webm|wmv)$" | sed 's/\([()|]\)/\\\1/g')"
-    mapfile -t files < <(find "$@" -type f -size "$MINSIZE" -iregex "$REGEX")
-    for muxInFile in "${files[@]}"; do
-        ((fileIter++))
+if [ "$PREVIEW" = false ] && [ "$REMUX" = true ]; then
+    REGEX="(^.*)\.(asf|avi|flv|m4[pv]|mp[4g]|mov|mpeg|m2?ts|ogv|qt|ts|vob|webm|wmv)$"
+    files=$(find "$@" -type f -size "$MINSIZE" -regextype posix-extended -iregex "$REGEX")
+    num_files=$(echo "$files" | wc -l)
+    fileIter=0
+    [ -n "${IFS+set}" ] && IFS_=$IFS
+    for muxInFile in $files; do
+		[ -n "${IFS_+set}" ] && IFS=$IFS_
+		fileIter=$((fileIter+1))
+		_filePos=$(filePos "$fileIter" "$num_files")
         isMatroska "$muxInFile" && continue
         muxOutFile=${muxInFile%.*}.mkv
         if [ -e "$muxOutFile" ]; then
             unset muxInFile muxOutFile
             continue
         fi
-        log_info "Remuxing '$muxInFile' to '$muxOutFile' $(filePos)."
+        log_info "Remuxing '$muxInFile' to '$muxOutFile' $_filePos."
         if "$FFMPEG" -n -loglevel error -stats -nostdin -hide_banner -i "$muxInFile" -c copy -map 0 "$muxOutFile"; then
             rm "$muxInFile"
         else
@@ -292,18 +299,23 @@ if [[ $PREVIEW == false && $REMUX == true ]]; then
     unset REGEX files fileIter
 fi
 
-mapfile -t files < <(find "$@" -type f -size "$MINSIZE" \( -iname "*.mk[av]" -o -iname "*.mk3d" \))
 filesProcessed=0
-for file in "${files[@]}"; do
-    ((fileIter++))
+files=$(find "$@" -type f -size "$MINSIZE" \( -iname "*.mk[av]" -o -iname "*.mk3d" \))
+num_files=$(printf '%s\n' "$files" | wc -l)
+fileIter=0
+[ -n "${IFS+set}" ] && IFS_=$IFS
+for file in $files; do
+    IFS=$IFS_
+    fileIter=$((fileIter+1))
+    _filePos=$(filePos "$fileIter" "$num_files")
     if ! isMatroska "$file"; then
-        echo -e "\e[92mNOTICE: '$file' is not a matroska file $(filePos).\e[0m"
+        log_notice "'$file' is not a matroska file $_filePos."
         continue
     fi
 
     ffmpegOut=$("$FFMPEG" -nostdin -hide_banner -i "$file" 2>&1)
-    if [[ ! $FORCE == true ]] && [[ $VERIFY == true ]] && [[ "$ffmpegOut" =~ $VERIFY_CHECK ]]; then
-        echo -e "\e[92mNOTICE: Skipping, replaygain tags already exist on file '$file' $(filePos).\e[0m"
+    if [ "$FORCE" != true ] && [ "$VERIFY" = true ] && match_ere "$VERIFY_CHECK" "$ffmpegOut"; then
+        log_notice "Skipping, replaygain tags already exist on file '$file' $_filePos."
         continue
     fi
 
@@ -311,9 +323,9 @@ for file in "${files[@]}"; do
 
     tracksProcessed=0
     for track in $tracks; do
-        log_info "Running ffmpeg using filter ${FFMPEGFILTER}, this can take a while. (track $track on file '$file') $(filePos) (REFLOUDNESS = $REFLOUDNESS LUFS)"
+        log_info "Running ffmpeg using filter ${FFMPEGFILTER}, this can take a while. (track $track on file '$file') $_filePos (REFLOUDNESS = $REFLOUDNESS LUFS)"
         ffmpegCmd="$FFMPEG -loglevel info -nostats -nostdin -hide_banner -i \"$file\" -map 0:$track -filter:a \""
-        if [[ $FFMPEGFILTER == "ebur128" ]]; then
+        if [ "$FFMPEGFILTER" = "ebur128" ]; then
             ffmpegCmd="${ffmpegCmd}ebur128=peak=$PEAKTYPE:framelog=quiet\" -f null -"
             echo "$ffmpegCmd"
             ffmpegOut=$(eval "$ffmpegCmd" 2>&1 | tr "\n" " " | sed "s/^.*\(Parsed_ebur128.*$\)/\1/" | sed "s/ \+/ /g")
@@ -321,7 +333,7 @@ for file in "${files[@]}"; do
             trackGain=$(lufsTodB "$(echo "$ffmpegOut" | grep -Po " I: $FLOAT_ERE LUFS" | cut -d\  -f3)")
             trackPeak=$(dBtoAmplitude "$(echo "$ffmpegOut" | grep -Po " Peak: $FLOAT_ERE dBFS" | cut -d\  -f3)")
             trackRange=$(printf "%0.2f" "$(echo "$ffmpegOut" | grep -Po " Loudness range: LRA: $FLOAT_ERE LU" | cut -d\  -f5)")
-        elif [[ $FFMPEGFILTER == "loudnorm" ]]; then
+        elif [ "$FFMPEGFILTER" = "loudnorm" ]; then
             ffmpegCmd="${ffmpegCmd}loudnorm=print_format=summary\" -f null -"
             echo "$ffmpegCmd"
             ffmpegOut=$(eval "$ffmpegCmd" 2>&1 | tr "\n" " " | sed "s/^.*\(Parsed_loudnorm.*$\)/\1/" | sed "s/ \+/ /g")
@@ -329,7 +341,7 @@ for file in "${files[@]}"; do
             trackGain=$(lufsTodB "$(echo "$ffmpegOut" | grep -Po "Input Integrated: $FLOAT_ERE LUFS" | cut -d\  -f3)")
             trackPeak=$(dBtoAmplitude "$(echo "$ffmpegOut" | grep -Po "Input True Peak: $FLOAT_ERE dBTP" | cut -d\  -f4)")
             trackRange=$(printf "%0.2f" "$(echo "$ffmpegOut" | grep -Po "Input LRA: $FLOAT_ERE LU" | cut -d\  -f3)")
-        elif [[ $FFMPEGFILTER == "replaygain" ]]; then
+        elif [ "$FFMPEGFILTER" = "replaygain" ]; then
             ffmpegCmd="${ffmpegCmd}replaygain\" -f null -"
             echo "$ffmpegCmd"
             ffmpegOut=$(eval "$ffmpegCmd" 2>&1 | sed "s/track_gain = -24.00 dB//" | sed "s/track_peak = 0.000000//")
@@ -338,12 +350,12 @@ for file in "${files[@]}"; do
         else
             exit 8
         fi
-        if [[ $trackGain == "" || $trackPeak == "" ]]; then
-            echo -e "\e[92mNOTICE: Problem finding $FFMPEGFILTER info from ffmpeg for track $track on file '$file' $(filePos).\e[0m"
+        if [ "$trackGain" = "" ] || [ "$trackPeak" = "" ]; then
+            log_notice "Problem finding $FFMPEGFILTER info from ffmpeg for track $track on file '$file' $_filePos."
             continue
         fi
-        log_info "Found: Gain ($trackGain dB | $(dBToLufs "$trackGain") LUFS), peak ($trackPeak amplitude | $(amplitudeToDB "$trackPeak") dB) for track $track on file '$file' $(filePos)."
-        if [[ $PREVIEW == true ]]; then
+        log_info "Found: Gain ($trackGain dB | $(dBToLufs "$trackGain") LUFS), peak ($trackPeak amplitude | $(amplitudeToDB "$trackPeak") dB) for track $track on file '$file' $_filePos."
+        if [ "$PREVIEW" = true ]; then
             log_info "PREVIEW mode is on, not applying tags, skipping to next track/file."
             continue
         fi
@@ -370,7 +382,7 @@ for file in "${files[@]}"; do
                         <Name>REPLAYGAIN_TRACK_PEAK</Name>
                         <String>$trackPeak</String>
                     </Simple>" > "$tmpFile"
-        if [[ $trackRange != "" ]]; then
+        if [ "$trackRange" != "" ]; then
             echo "
                     <Simple>
                         <Name>REPLAYGAIN_TRACK_RANGE</Name>
@@ -384,15 +396,15 @@ for file in "${files[@]}"; do
         sed -i "s/^            //g" "$tmpFile"
         sed -i "/^[[:space:]]*$/d" "$tmpFile"
         mkvpropedit --tags track:"$((track+1))":"$tmpFile" "$file"
-        if [[ $VERIFY == true ]] && [[ ! $("$FFMPEG" -nostdin -hide_banner -i "$file" 2>&1) =~ $VERIFY_CHECK ]]; then
-            log_warn "Replaygain has not been applied for track $track on file '$file' $(filePos)."
+        if [ "$VERIFY" = true ] && ! match_ere "$VERIFY_CHECK" "$("$FFMPEG" -nostdin -hide_banner -i "$file" 2>&1)"; then
+            log_warn "Replaygain has not been applied for track $track on file '$file' $_filePos."
             continue
         fi
-        log_info "Succesfully applied replaygain tags for track $track on file '$file' $(filePos)."
-        ((tracksProcessed++))
+        log_info "Succesfully applied replaygain tags for track $track on file '$file' $_filePos."
+        tracksProcessed=$((tracksProcessed+1))
     done
-    [[ $tracksProcessed -gt 0 ]] && ((filesProcessed++))
+    [ $tracksProcessed -gt 0 ] && filesProcessed=$(( filesProcessed + 1 ))
 done
-[[ $filesProcessed -gt 0 ]] && cleantmp 0
+[ $filesProcessed -gt 0 ] && cleantmp 0
 
 # vi: sw=4 ts=4 sts=4 smarttab

--- a/mkvrg
+++ b/mkvrg
@@ -360,4 +360,4 @@ for file in "${files[@]}"; do
 done
 [[ $filesProcessed -gt 0 ]] && cleantmp 0
 
-# vi: sw=4
+# vi: sw=4 ts=4 sts=4 smarttab

--- a/mkvrg
+++ b/mkvrg
@@ -151,40 +151,20 @@ log_message ( ) {
     printf '%b%s\e[0m\n' "$color" "$prefix: $text"
 } >&2
 
-log_error ( ) {
-    log_message error "$@"
-}
+log_error ( ) { log_message error "$@"; }
+log_warn ( ) { log_message warn "$@"; }
+log_notice ( ) { log_message notice "$@"; }
+log_info ( ) { log_message info "$@"; }
 
-log_warn ( ) {
-    log_message warn "$@"
-}
-log_notice ( ) {
-    log_message notice "$@"
-}
+isint ( ) { match_ere '^[+-]?[[:digit:]]+$' "$1"; }
+isfloat ( ) { match_ere '^[+-]?[[:digit:]]*\.[[:digit:]]+$' "$1"; }
+isnum ( ) { isint "$1" || isfloat "$1"; }
 
-log_info ( ) {
-    log_message info "$@"
-}
+cmd_exists ( ) { command -v "$1"; } >/dev/null 2>&1
 
 match_ere ( ) { # match string against extended reqex
     regex="$1" && shift
     echo "$*" | grep -Eq "$regex"
-}
-
-cmd_exists ( ) {
-    command -v "$1"
-} >/dev/null 2>&1
-
-isint ( ) {
-    match_ere '^[+-]?[[:digit:]]+$' "$1"
-}
-
-isfloat ( ) {
-    match_ere '^[+-]?[[:digit:]]*\.[[:digit:]]+$' "$1"
-}
-
-isnum ( ) {
-    isint "$1" || isfloat "$1"
 }
 
 if ! match_ere '^(ebur128|loudnorm|replaygain)$' "$FFMPEGFILTER"; then

--- a/mkvrg
+++ b/mkvrg
@@ -1,4 +1,5 @@
 #!/bin/sh
+# {{{ License
 cat > /dev/null <<LICENSE
     Copyright (C) 2016,2023  kevinlekiller
     Copyright (C) 2016  WhitePeter
@@ -18,7 +19,9 @@ cat > /dev/null <<LICENSE
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
 LICENSE
+# License }}}
 
+# {{{ Help
 reqProgs="awk ffmpeg ffprobe file find grep mkvpropedit mktemp sed"
 [ "$1" = "--help" ] || [ "$1" = "-h" ] &&
     { cat; exit; } <<DESCRIPTION
@@ -100,9 +103,13 @@ reqProgs="awk ffmpeg ffprobe file find grep mkvpropedit mktemp sed"
     PREVIEW=[true|false] -> If set to true, no files will be modified, values will be displayed on the console.
                             Defaults to PREVIEW=false
 DESCRIPTION
+# Help }}}
+
+# {{{ ENV VARS
 #########################################################################################
 ##################################### ENV VARS ##########################################
 #########################################################################################
+LC_NUMERIC=C
 VERIFY=${VERIFY:-true}
 FORCE=${FORCE:-false}
 MINSIZE=${MINSIZE:-"+0"}
@@ -115,9 +122,10 @@ PREVIEW=${PREVIEW:-false}
 #########################################################################################
 ################################### ENV VARS End ########################################
 #########################################################################################
+# ENV VARS }}}
 
-LC_NUMERIC=C
-
+# {{{ Logging
+# {{{ log_message ( )
 log_message ( ) {
     level=$1
     case $level in
@@ -149,26 +157,33 @@ log_message ( ) {
     text="$*"
     printf '%b%s\e[0m\n' "$color" "$prefix: $text"
 } >&2
+# log_message ( ) }}}
 
 log_error ( ) { log_message error "$@"; }
 log_warn ( ) { log_message warn "$@"; }
 log_notice ( ) { log_message notice "$@"; }
 log_info ( ) { log_message info "$@"; }
+# Logging }}}
 
+# {{{ Number checking
 # for more convenient regex construction
 FLOAT_ERE='[+-]?[[:digit:]]*\.[[:digit:]]+'
 
 isint ( ) { match_ere '^[+-]?[[:digit:]]+$' "$1"; }
 isfloat ( ) { match_ere "^$FLOAT_ERE$" "$1"; }
 isnum ( ) { isint "$1" || isfloat "$1"; }
+# Number checking }}}
 
 cmd_exists ( ) { command -v "$1"; } >/dev/null 2>&1
 
-match_ere ( ) { # match string against extended reqex
+# {{{ match_ere ( )  # match string against extended reqex
+match_ere ( ) {
     regex="$1" && shift
     echo "$*" | grep -Eq "$regex"
 }
+# }}}
 
+# {{{ Initial checks
 if ! match_ere '^(ebur128|loudnorm|replaygain)$' "$FFMPEGFILTER"; then
     log_error "Invalid FFMPEGFILTER."
     exit 2
@@ -196,13 +211,17 @@ for reqProg in $reqProgs; do
     fi
 done
 unset reqProg reqProgs
+# Initial checks }}}
 
+#{{{ Create temporary file
 tmpFile="$(mktemp)"
 if [ ! -w "$tmpFile" ]; then
     log_error "Could not create temp file $tmpFile. Check permissions."
     exit 7
 fi
+# Create temporary file }}}
 
+#{{{ Set reference loudness
 REFLOUDNESS=-23.00
 case "$FFMPEGFILTER" in
     loudnorm)	REFLOUDNESS=-24.00 ;;
@@ -211,6 +230,7 @@ esac
 
 [ "$FFMPEGFILTER" != "replaygain" ] &&
     REFLOUDNESS=$(awk "BEGIN{print $REFLOUDNESS + $LOUDNESSOFFSET}")
+# Set reference loudness }}}
 
 VERIFY_CHECK="${REPLAYGAIN_ALGORITHM}: ${FFMPEGFILTER}"
 
@@ -392,4 +412,4 @@ for file in $files; do
 done
 [ $filesProcessed -gt 0 ] && cleantmp 0
 
-# vi: sw=4 sts=4 smarttab
+# vi: sw=4 sts=4 smarttab foldmethod=marker

--- a/mkvrg
+++ b/mkvrg
@@ -237,8 +237,8 @@ VERIFY_CHECK="${REPLAYGAIN_ALGORITHM}: ${FFMPEGFILTER}"
 
 trap cleantmp HUP INT QUIT TERM
 cleantmp ( ) {
-    [ -f "$muxInFile" ] && [ -f "$muxOutFile" ] && rm -f "$muxOutFile"
-    rm -f "$tmpFile"
+    [ -f "$muxInFile" ] && [ -f "$muxOutFile" ] && rm "$muxOutFile"
+    rm "$tmpFile"
     [ -n "$1" ] && exit "$1" || exit 1
 }
 
@@ -283,9 +283,9 @@ if [[ $PREVIEW == false && $REMUX == true ]]; then
         fi
         log_info "Remuxing '$muxInFile' to '$muxOutFile' $(filePos)."
         if "$FFMPEG" -n -loglevel error -stats -nostdin -hide_banner -i "$muxInFile" -c copy -map 0 "$muxOutFile"; then
-            rm -f "$muxInFile"
+            rm "$muxInFile"
         else
-            rm -f "$muxOutFile"
+            rm "$muxOutFile"
         fi
         unset muxInFile muxOutFile
     done

--- a/mkvrg
+++ b/mkvrg
@@ -226,12 +226,17 @@ fi
 #{{{ cleantmp ( )
 cleantmp ( ) {
     exit_code=$?
+    log_info "Caught signal $1, cleaning up."
     [ -f "$muxInFile" ] && [ -f "$muxOutFile" ] && rm "$muxOutFile"
     rm "$tmpFile"
+    trap - EXIT
     exit $exit_code
 }
 #}}} cleantmp ( ) 
-trap cleantmp HUP INT QUIT TERM EXIT
+for sig in HUP INT QUIT TERM EXIT; do
+    # shellcheck disable=2064
+    trap "cleantmp $sig" "$sig"
+done
 
 #{{{ Set reference loudness
 REFLOUDNESS=-23.00

--- a/mkvrg
+++ b/mkvrg
@@ -122,7 +122,7 @@ LC_NUMERIC=C
 # for more convenient regex construction
 FLOAT_ERE='[+-]?[0-9]+\.[0-9]+'
 
-log_message () {
+log_message ( ) {
     level=$1
     case $level in
 	error)
@@ -151,42 +151,42 @@ log_message () {
 	    ;;
     esac
     text="$*"
-    printf '%b%s\e[0m\n' "$color" "$prefix: $text" >&2
-}
+    printf '%b%s\e[0m\n' "$color" "$prefix: $text"
+} >&2
 
-log_error () {
+log_error ( ) {
     log_message error "$@"
 }
 
-log_warn () {
+log_warn ( ) {
     log_message warn "$@"
 }
-log_notice () {
+log_notice ( ) {
     log_message notice "$@"
 }
 
-log_info () {
+log_info ( ) {
     log_message info "$@"
 }
 
-match_ere () { # match string against extended reqex
+match_ere ( ) { # match string against extended reqex
     regex="$1" && shift
     echo "$@" | grep -Eq "$regex"
 }
 
-cmd_exists () {
-    command -v "$1" >/dev/null 2>&1
-}
+cmd_exists ( ) {
+    command -v "$1"
+} >/dev/null 2>&1
 
-isint () {
+isint ( ) {
     match_ere '^[+-]?[[:digit:]]+$' "$1"
 }
 
-isfloat () {
+isfloat ( ) {
     match_ere '^[+-]?[[:digit:]]*\.[[:digit:]]+$' "$1"
 }
 
-isnum () {
+isnum ( ) {
     isint "$1" || isfloat "$1"
 }
 
@@ -236,36 +236,36 @@ esac
 VERIFY_CHECK="${REPLAYGAIN_ALGORITHM}: ${FFMPEGFILTER}"
 
 trap cleantmp HUP INT QUIT TERM
-cleantmp() {
+cleantmp ( ) {
     [ -f "$muxInFile" ] && [ -f "$muxOutFile" ] && rm -f "$muxOutFile"
     rm -f "$tmpFile"
     [ -n "$1" ] && exit "$1" || exit 1
 }
 
-lufsTodB() {
+lufsTodB ( ) {
     isnum "$1" || return 1
     awk "BEGIN{printf \"%0.2f\", $REFLOUDNESS - $1}"
 }
 
-dBToLufs() {
+dBToLufs ( ) {
     lufsTodB "$1"
 }
 
-dBtoAmplitude() {
+dBtoAmplitude ( ) {
     isnum "$1" || return 1
     printf "%06f" "$(awk "BEGIN{print 10^($1/20)}")"
 }
 
-amplitudeToDB() {
+amplitudeToDB ( ) {
     isnum "$1" || return 1
     printf "%0.2f" "$(awk "BEGIN{print 20*log($1)/log(10)}")"
 }
 
-isMatroska() {
+isMatroska ( ) {
      match_ere "Matroska" "$(file "$1")"
 }
 
-filePos() {
+filePos ( ) {
     [[ ! $fileIter =~ ^[0-9]+$ ]] || [[ ! ${#files[@]} =~ ^[0-9]+$ ]] && return;
     echo "(file $fileIter of ${#files[@]}, $(awk "BEGIN{print 100*($fileIter/${#files[@]})}")%)"
 }

--- a/mkvrg
+++ b/mkvrg
@@ -165,16 +165,18 @@ log_notice ( ) { log_message notice "$@"; }
 log_info ( ) { log_message info "$@"; }
 # Logging }}}
 
-# {{{ Number checking
+# {{{ Checking functions
 # for more convenient regex construction
 FLOAT_ERE='[+-]?[[:digit:]]*\.[[:digit:]]+'
 
 isint ( ) { match_ere '^[+-]?[[:digit:]]+$' "$1"; }
 isfloat ( ) { match_ere "^$FLOAT_ERE$" "$1"; }
 isnum ( ) { isint "$1" || isfloat "$1"; }
-# Number checking }}}
 
 cmd_exists ( ) { command -v "$1"; } >/dev/null 2>&1
+
+isMatroska ( ) { match_ere "Matroska" "$(file "$1")"; }
+# }}} Checking functions
 
 # {{{ match_ere ( )  # match string against extended reqex
 match_ere ( ) {
@@ -242,8 +244,7 @@ esac
     REFLOUDNESS=$(awk "BEGIN{print $REFLOUDNESS + $LOUDNESSOFFSET}")
 # Set reference loudness }}}
 
-VERIFY_CHECK="${REPLAYGAIN_ALGORITHM}: ${FFMPEGFILTER}"
-
+#{{{ Math functions
 lufsTodB ( ) {
     isnum "$1" || return 1
     awk "BEGIN{print $REFLOUDNESS - $1}"
@@ -262,18 +263,18 @@ amplitudeToDB ( ) {
     isnum "$1" || return 1
     awk "BEGIN{print 20*log($1)/log(10)}"
 }
+#}}} Math functions
 
-isMatroska ( ) {
-     match_ere "Matroska" "$(file "$1")"
-}
-
+#{{{ filePos ( )  # Show progress
 filePos ( ) {
     fileIter=$1
     num_files=$2
     ! isint "$fileIter" || ! isint "$num_files" && return 1;
     echo "(file $fileIter of $num_files, $(awk "BEGIN{print 100*($fileIter/$num_files)}")%)"
 }
+#}}} filePos ( )
 
+#{{{ Remux files
 if [ "$PREVIEW" = false ] && [ "$REMUX" = true ]; then
     REGEX="(^.*)\.(asf|avi|flv|m4[pv]|mp[4g]|mov|mpeg|m2?ts|ogv|qt|ts|vob|webm|wmv)$"
     files=$(find "$@" -type f -size "$MINSIZE" -regextype posix-extended -iregex "$REGEX")
@@ -296,13 +297,17 @@ if [ "$PREVIEW" = false ] && [ "$REMUX" = true ]; then
         if "$FFMPEG" -n -loglevel error -stats -nostdin -hide_banner -i "$muxInFile" -c copy -map 0 "$muxOutFile"; then
             rm "$muxInFile"
         else
+	    log_error "Something went wrong while muxing $muxOutFile, deleting."
             rm "$muxOutFile"
         fi
         unset muxInFile muxOutFile
     done
     unset REGEX files fileIter
 fi
+#}}} Remux files
 
+#{{{ Main action: Calculating gain and tagging files
+VERIFY_CHECK="${REPLAYGAIN_ALGORITHM}: ${FFMPEGFILTER}"
 filesProcessed=0
 # FIXME: if there were non-mkv files in $@ find will throw an error because they got remuxed
 files=$(find "$@" -type f -size "$MINSIZE" \( -iname "*.mk[av]" -o -iname "*.mk3d" \))
@@ -311,6 +316,7 @@ fileIter=0
 IFS_=$IFS
 # newline as IFS
 IFS="$(printf '\n\r')"
+#{{{ file loop
 for file in $files; do
     IFS=$IFS_
     fileIter=$((fileIter+1))
@@ -328,8 +334,10 @@ for file in $files; do
 
     tracks=$(ffprobe -v error -of default=nw=1:nk=1 -select_streams a -show_entries stream=index "$file")
 
+    #{{{ track loop
     tracksProcessed=0
     for track in $tracks; do
+	#{{{ gain calculation
         log_info "Running ffmpeg using filter ${FFMPEGFILTER}, this can take a while. (track $track on file '$file') $_filePos (REFLOUDNESS = $REFLOUDNESS LUFS)"
         ffmpegCmd="$FFMPEG -loglevel info -nostats -nostdin -hide_banner -i \"$file\" -map 0:$track -filter:a \""
         if [ "$FFMPEGFILTER" = "ebur128" ]; then
@@ -366,7 +374,9 @@ for file in $files; do
             log_info "PREVIEW mode is on, not applying tags, skipping to next track/file."
             continue
         fi
+	#}}} gain calculation
 
+	#{{{ track tag generation
         echo "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>
             <!DOCTYPE Tags SYSTEM \"matroskatags.dtd\">
             <Tags>
@@ -409,10 +419,12 @@ for file in $files; do
             continue
         fi
         log_info "Succesfully applied replaygain tags for track $track on file '$file' $_filePos."
+	#}}} track tag generation
         tracksProcessed=$((tracksProcessed+1))
-    done
-    [ $tracksProcessed -gt 0 ] && filesProcessed=$(( filesProcessed + 1 ))
+    done; [ $tracksProcessed -gt 0 ] && filesProcessed=$(( filesProcessed + 1 ))
+    #}}} track loop
 done
-[ $filesProcessed -gt 0 ]
+#}}} file loop
+#}}} Main action: Calculating gain and tagging files
 
 # vi: sw=4 sts=4 smarttab foldmethod=marker

--- a/mkvrg
+++ b/mkvrg
@@ -122,79 +122,107 @@ LC_NUMERIC=C
 # for more convenient regex construction
 FLOAT_ERE='[+-]?[0-9]+\.[0-9]+'
 
+log_error() {
+    printf "\e[31mERROR: %s\e[0m\n" "$@" >&2
+}
 
-if [[ ! $FFMPEGFILTER =~ ^(ebur128|loudnorm|replaygain)$ ]]; then
-    echo -e "\e[31mERROR: Invalid FFMPEGFILTER.\e[0m" > /dev/stderr
+match_ere () { # match string against extended reqex
+    regex="$1" && shift
+    echo "$@" | grep -Eq "$regex"
+}
+
+cmd_exists () {
+    command -v "$1" >/dev/null 2>&1
+}
+
+isint () {
+    match_ere '^[+-]?[[:digit:]]+$' "$1"
+}
+
+isfloat () {
+    match_ere '^[+-]?[[:digit:]]*\.[[:digit:]]+$' "$1"
+}
+
+isnum () {
+    isint "$1" || isfloat "$1"
+}
+
+if ! match_ere '^(ebur128|loudnorm|replaygain)$' "$FFMPEGFILTER"; then
+    log_error "Invalid FFMPEGFILTER."
     exit 2
 fi
 
-if [[ ! $PEAKTYPE =~ ^(sample|true)$ ]]; then
-    echo -e "\e[31mERROR: PEAKTYPE must be either sample or true.\e[0m" > /dev/stderr
+if ! match_ere '^(sample|true)$' "$PEAKTYPE"; then
+    log_error "PEAKTYPE must be either sample or true."
     exit 3
 fi
 
-if [[ ! $LOUDNESSOFFSET =~ ^\-?[0-9]+\.[0-9]+$ ]]; then
-    echo -e "\e[31mERROR: Invalid value for LOUDNESSOFFSET.\e[0m" > /dev/stderr
+if ! isnum "$LOUDNESSOFFSET"; then
+    log_error "Invalid value for LOUDNESSOFFSET."
     exit 4
 fi
 
-if ! command -v "$FFMPEG" &> /dev/null; then
-    echo -e "\e[31mERROR: Unable to find the ffmpeg executable.\e[0m" > /dev/stderr
+if ! cmd_exists "$FFMPEG"; then
+    log_error "Unable to find the ffmpeg executable."
     exit 5
 fi
 
-reqProgs="awk file find grep mkvpropedit mktemp sed"
 for reqProg in $reqProgs; do
-    if ! command -v "$reqProg" &> /dev/null; then
-        echo -e "\e[31mERROR: This program could not be found: $reqProg\e[0m" > /dev/stderr
-        exit 6
+    if ! cmd_exists "$reqProg"; then
+	log_error "This program could not be found: $reqProg"
+	exit 6
     fi
 done
 unset reqProg reqProgs
 
 tmpFile="$(mktemp)"
-if [[ ! -f $tmpFile ]] || [[ ! -w $tmpFile ]]; then
-    echo -e "\e[31mERROR: Could not create temp file $tmpFile. Check permissions.\e[0m" > /dev/stderr
+if [ ! -w "$tmpFile" ]; then
+    log_error "Could not create temp file $tmpFile. Check permissions."
     exit 7
 fi
 
-REFLOUDNESS="-23.00"
-[[ $FFMPEGFILTER == "loudnorm" ]] && REFLOUDNESS="-24.00"
-[[ $FFMPEGFILTER == "replaygain" ]] && REFLOUDNESS="-18.00"
-[[ $FFMPEGFILTER != "replaygain" ]] && REFLOUDNESS="$(printf "%0.2f" "$(awk "BEGIN{print ($REFLOUDNESS + $LOUDNESSOFFSET)}")")"
+REFLOUDNESS="-23"
+case "$FFMPEGFILTER" in
+    loudnorm)	REFLOUDNESS=-24.00 ;;
+    replaygain)	REFLOUDNESS=-18.00 ;;
+esac
+
+[ "$FFMPEGFILTER" != "replaygain" ] &&
+    REFLOUDNESS=$(awk "BEGIN{printf \"%0.2f\", $REFLOUDNESS + $LOUDNESSOFFSET}")
+
 VERIFY_CHECK="${REPLAYGAIN_ALGORITHM}: ${FFMPEGFILTER}"
 
-trap cleantmp SIGHUP SIGINT SIGQUIT SIGTERM
-function cleantmp() {
-    [[ -f $muxInFile && -f $muxOutFile ]] && rm -f "$muxOutFile"
+trap cleantmp HUP INT QUIT TERM
+cleantmp() {
+    [ -f "$muxInFile" ] && [ -f "$muxOutFile" ] && rm -f "$muxOutFile"
     rm -f "$tmpFile"
-    [[ -n $1 ]] && exit "$1" || exit 1
+    [ -n "$1" ] && exit "$1" || exit 1
 }
 
-function lufsTodB() {
-    [[ $1 =~ ^$ ]] && echo "" && return
-    printf "%0.2f" "$(awk "BEGIN{print ($REFLOUDNESS - $1)}")"
+lufsTodB() {
+    isnum "$1" || return 1
+    awk "BEGIN{printf \"%0.2f\", $REFLOUDNESS - $1}"
 }
 
-function dBToLufs() {
+dBToLufs() {
     lufsTodB "$1"
 }
 
-function dBtoAmplitude() {
-    [[ $1 =~ ^$ ]] && $1 && echo "" && return
+dBtoAmplitude() {
+    isnum "$1" || return 1
     printf "%06f" "$(awk "BEGIN{print 10^($1/20)}")"
 }
 
-function amplitudeToDB() {
-    [[ $1 =~ ^$ ]] && $1 && echo "" && return
+amplitudeToDB() {
+    isnum "$1" || return 1
     printf "%0.2f" "$(awk "BEGIN{print 20*log($1)/log(10)}")"
 }
 
-function isMatroska() {
-     [[ $(file "$1") =~ "Matroska" ]] && return 0 || return 1
+isMatroska() {
+     match_ere "Matroska" "$(file "$1")"
 }
 
-function filePos() {
+filePos() {
     [[ ! $fileIter =~ ^[0-9]+$ ]] || [[ ! ${#files[@]} =~ ^[0-9]+$ ]] && return;
     echo "(file $fileIter of ${#files[@]}, $(awk "BEGIN{print 100*($fileIter/${#files[@]})}")%)"
 }

--- a/mkvrg
+++ b/mkvrg
@@ -276,11 +276,11 @@ if [ "$PREVIEW" = false ] && [ "$REMUX" = true ]; then
     fileIter=0
     [ -n "${IFS+set}" ] && IFS_=$IFS
     for muxInFile in $files; do
-		[ -n "${IFS_+set}" ] && IFS=$IFS_
-		fileIter=$((fileIter+1))
-		_filePos=$(filePos "$fileIter" "$num_files")
-        isMatroska "$muxInFile" && continue
-        muxOutFile=${muxInFile%.*}.mkv
+	[ -n "${IFS_+set}" ] && IFS=$IFS_
+	fileIter=$((fileIter+1))
+	_filePos=$(filePos "$fileIter" "$num_files")
+	isMatroska "$muxInFile" && continue
+	muxOutFile=${muxInFile%.*}.mkv
         if [ -e "$muxOutFile" ]; then
             unset muxInFile muxOutFile
             continue
@@ -404,4 +404,4 @@ for file in $files; do
 done
 [ $filesProcessed -gt 0 ] && cleantmp 0
 
-# vi: sw=4 ts=4 sts=4 smarttab
+# vi: sw=4 sts=4 smarttab

--- a/mkvrg
+++ b/mkvrg
@@ -23,8 +23,7 @@ LICENSE
 
 # {{{ Help
 reqProgs="awk ffmpeg ffprobe file find grep mkvpropedit mktemp sed"
-[ "$1" = "--help" ] || [ "$1" = "-h" ] &&
-    { cat; exit; } <<DESCRIPTION
+print_help ( ) { cat; } >&2 <<DESCRIPTION
     mkvrg - Apply replaygain tags to matroska files without remuxing (gain is calculated using ffmpeg and tags are applied using mkvpropedit).
 
     Bash script for analyzing audio tracks in matroska files with ffmpeg and
@@ -48,60 +47,60 @@ reqProgs="awk ffmpeg ffprobe file find grep mkvpropedit mktemp sed"
     ./mkvrg test.mkv              ; Process test.mkv in current folder.
     ./mkvrg Videos/               ; Recursive search in Videos folder for matroska files.
     ./mkvrg test.mkv Videos/      ; Process test.mkv in current folder and recursive
-                                    search in Videos folder for matroska files.
+				    search in Videos folder for matroska files.
     FORCE=true ./mkvrg test.mkv   ; Process test.mkv even if it already has replaygain tags.
     MINSIZE=+100M ./mkvrg         ; Recursive search in current folder for matroska
-                                    files larger than 100MiB.
+				    files larger than 100MiB.
     FFMPEGFILTER=loudnorm ./mkvrg ; Use loudnorm ffmpeg filter to scan found files.
 
     Environment Variables:
 
     VERIFY=[true|false]  -> Check if the file already has tags or if tags were written succesfully.
-                            Defaults to VERIFY=true
+			    Defaults to VERIFY=true
     FORCE=[true|false]   -> Force mkvrg to process matroska files, even if they already have replaygain tags.
-                            If VERIFY=false, files will always be processed.
-                            Defaults to FORCE=false
+			    If VERIFY=false, files will always be processed.
+			    Defaults to FORCE=false
     MINSIZE=+[0-9][KMBG] -> Minimum matroska file size to work on.
-                            Set to MINSIZE=+0 to disable.
-                            For example, set MINSIZE=+50M to ignore files under 50MB.
-                            Defaults to MINSIZE=+0
+			    Set to MINSIZE=+0 to disable.
+			    For example, set MINSIZE=+50M to ignore files under 50MB.
+			    Defaults to MINSIZE=+0
     REMUX=[true|false]   -> Remux non matroska files to .mkv before scanning for .mkv files.
-                            Defaults to REMUX=false
+			    Defaults to REMUX=false
     FFMPEG=[path]        ->  Which ffmpeg executable to use.
-                            Set to FFMPEG=ffmpeg to use the one in PATH.
-                            For example, set to FFMPEG=/home/user/ffmpeg/ffmpeg
-                            Defaults to FFMPEG=ffmpeg
+			    Set to FFMPEG=ffmpeg to use the one in PATH.
+			    For example, set to FFMPEG=/home/user/ffmpeg/ffmpeg
+			    Defaults to FFMPEG=ffmpeg
     FFMPEGFILTER=        ->
-        [ebur128|loudnorm|replaygain]
-                            Which ffmpeg filter to use for scanning the audio.
-                            Each filter calculates the gain/peak differently.
-                            Lower reference loudness = quieter output (replaygain will be louder than ebur128 for example).
-                            Faster speed = less time it takes to scan the audio.
-                            replaygain: Speed:               Fast.      Roughly 10x faster than loudnorm.
-                                        Reference loudness: -18.00 LUFS
-                            ebur128:    Speed:               Normal.    Roughly 5x faster than loudnorm.
-                                                                        Note: This is with true peak calculation, which is slower.
-                                        Reference loudness: -23.00 LUFS
-                            loudnorm:   Speed:               Slow.
-                                        Reference loudness: -24.00 LUFS
-                            Defaults to FFMPEGFILTER=ebur128
+	[ebur128|loudnorm|replaygain]
+			    Which ffmpeg filter to use for scanning the audio.
+			    Each filter calculates the gain/peak differently.
+			    Lower reference loudness = quieter output (replaygain will be louder than ebur128 for example).
+			    Faster speed = less time it takes to scan the audio.
+			    replaygain: Speed:               Fast.      Roughly 10x faster than loudnorm.
+					Reference loudness: -18.00 LUFS
+			    ebur128:    Speed:               Normal.    Roughly 5x faster than loudnorm.
+									Note: This is with true peak calculation, which is slower.
+					Reference loudness: -23.00 LUFS
+			    loudnorm:   Speed:               Slow.
+					Reference loudness: -24.00 LUFS
+			    Defaults to FFMPEGFILTER=ebur128
     PEAKTYPE=            ->
-         [true|sample]
-                            Type of peak calculation to use.
-                            Note: Only used for ebur128 filter.
-                            sample : Faster but less accurate. Varies from file to file, but can be up to 2x faster in testing.
-                            true : Slower but accurate.
-                            Defaults to PEAKTYPE=true
+	 [true|sample]
+			    Type of peak calculation to use.
+			    Note: Only used for ebur128 filter.
+			    sample : Faster but less accurate. Varies from file to file, but can be up to 2x faster in testing.
+			    true : Slower but accurate.
+			    Defaults to PEAKTYPE=true
     LOUDNESSOFFSET=
-          [+-]0.0        -> Affects the calculation of LUFS to dB, which affects how loud or quiet the audio will be.
-                            Adding a positive number will make the audio louder, adding a negative number will make it quieter.
-                            For example, the reference loudness of ebur128 is -23.00, if we set LOUDNESSOFFSET=5.00, the gain
-                            will be roughly the same as what the replaygain  (-18.00 reference) filter will calculate.
-                            Note: This only affects ebur128 and loudnorm filters.
-                            Disable by setting LOUDNESSOFFSET=0.0
-                            Defaults to LOUDNESSOFFSET=0.0
+	  [+-]0.0        -> Affects the calculation of LUFS to dB, which affects how loud or quiet the audio will be.
+			    Adding a positive number will make the audio louder, adding a negative number will make it quieter.
+			    For example, the reference loudness of ebur128 is -23.00, if we set LOUDNESSOFFSET=5.00, the gain
+			    will be roughly the same as what the replaygain  (-18.00 reference) filter will calculate.
+			    Note: This only affects ebur128 and loudnorm filters.
+			    Disable by setting LOUDNESSOFFSET=0.0
+			    Defaults to LOUDNESSOFFSET=0.0
     PREVIEW=[true|false] -> If set to true, no files will be modified, values will be displayed on the console.
-                            Defaults to PREVIEW=false
+			    Defaults to PREVIEW=false
 DESCRIPTION
 # Help }}}
 
@@ -165,6 +164,13 @@ log_notice ( ) { log_message notice "$@"; }
 log_info ( ) { log_message info "$@"; }
 # Logging }}}
 
+# {{{ match_ere ( )  # match string against extended reqex
+match_ere ( ) {
+    regex="$1" && shift
+    echo "$*" | grep -Eq "$regex"
+}
+# }}}
+
 # {{{ Checking functions
 # for more convenient regex construction
 FLOAT_ERE='[+-]?[[:digit:]]*\.[[:digit:]]+'
@@ -178,12 +184,44 @@ cmd_exists ( ) { command -v "$1"; } >/dev/null 2>&1
 isMatroska ( ) { match_ere "Matroska" "$(file "$1")"; }
 # }}} Checking functions
 
-# {{{ match_ere ( )  # match string against extended reqex
-match_ere ( ) {
-    regex="$1" && shift
-    echo "$*" | grep -Eq "$regex"
-}
-# }}}
+#{{{ Option parsing
+while getopts ":-:fhm:O:pV" o; do
+    __ill_v ( ) { log_error "-$1: Illegal value '$2'"; exit 1; }
+    __ill_o ( ) { log_error "Illegal option: '-$1'"; exit 1; }
+    case $o in
+	-)  # Long options MUST be delimited by '=' from their values
+	    n=$(echo "$OPTARG" | cut -d= -f1)
+	    v=$(echo "$OPTARG" | cut -d= -f2)
+	    case $n in
+		filter)
+		    { match_ere '^(ebur128|loudnorm|replaygain)$' "$v" && FFMPEGFILTER="$v"; }\
+			|| __ill_v "-$n" "$v" ;;
+		force)
+		    FORCE=true ;;
+		minsize)
+		    MINSIZE=$v ;;
+		no-verify)
+		    VERIFY=false ;;
+		peak)
+		    { match_ere '^(true|sample)$' "$v" && PEAKTYPE="$v"; }\
+			|| __ill_v "-$n" "$v" ;;
+		help)
+		    print_help && exit ;;
+		*)
+		    __ill_o "-$n"
+	    esac
+	    ;;
+	f)  FORCE=true ;;
+	m)  { isnum "$OPTARG" && MINSIZE=$OPTARG; } || __ill_v "$o" "$OPTARG" ;;
+	O)  { isnum "$OPTARG" && LOUDNESSOFFSET=$OPTARG; } || __ill_v "$o" "$OPTARG" ;;
+	p)  PREVIEW=true ;;
+	V)  VERIFY=false ;;
+	h)  print_help && exit ;;
+	\?) __ill_o "$OPTARG"
+    esac
+done
+shift $((OPTIND-1))
+#}}} Option parsing
 
 # {{{ Initial checks
 if ! match_ere '^(ebur128|loudnorm|replaygain)$' "$FFMPEGFILTER"; then

--- a/mkvrg
+++ b/mkvrg
@@ -270,73 +270,9 @@ amplitudeToDB ( ) {
 }
 #}}} Math functions
 
-#{{{ filePos ( )  # Show progress
-filePos ( ) {
-    fileIter=$1
-    num_files=$2
-    ! isint "$fileIter" || ! isint "$num_files" && return 1;
-    echo "(file $fileIter of $num_files, $(awk "BEGIN{print 100*($fileIter/$num_files)}")%)"
-}
-#}}} filePos ( )
-
-#{{{ Remux files
-if [ "$PREVIEW" = false ] && [ "$REMUX" = true ]; then
-    REGEX="(^.*)\.(asf|avi|flv|m4[pv]|mp[4g]|mov|mpeg|m2?ts|ogv|qt|ts|vob|webm|wmv)$"
-    files=$(find "$@" -type f -size "$MINSIZE" -regextype posix-extended -iregex "$REGEX")
-    num_files=$(echo "$files" | wc -l)
-    fileIter=0
-    IFS_=$IFS
-    # newline as IFS
-    IFS="$(printf '\n\r')"
-    for muxInFile in $files; do
-	IFS=$IFS_
-	fileIter=$((fileIter+1))
-	_filePos=$(filePos "$fileIter" "$num_files")
-	isMatroska "$muxInFile" && continue
-	muxOutFile=${muxInFile%.*}.mkv
-        if [ -e "$muxOutFile" ]; then
-            unset muxInFile muxOutFile
-            continue
-        fi
-        log_info "Remuxing '$muxInFile' to '$muxOutFile' $_filePos."
-        if "$FFMPEG" -n -loglevel error -stats -nostdin -hide_banner -i "$muxInFile" -c copy -map 0 "$muxOutFile"; then
-            rm "$muxInFile"
-        else
-	    log_error "Something went wrong while muxing $muxOutFile, deleting."
-            rm "$muxOutFile"
-        fi
-        unset muxInFile muxOutFile
-    done
-    unset REGEX files fileIter
-fi
-#}}} Remux files
-
-#{{{ Main action: Calculating gain and tagging files
-VERIFY_CHECK="${REPLAYGAIN_ALGORITHM}: ${FFMPEGFILTER}"
-filesProcessed=0
-# FIXME: if there were non-mkv files in $@ find will throw an error because they got remuxed
-files=$(find "$@" -type f -size "$MINSIZE" \( -iname "*.mk[av]" -o -iname "*.mk3d" \))
-num_files=$(printf '%s\n' "$files" | wc -l)
-fileIter=0
-IFS_=$IFS
-# newline as IFS
-IFS="$(printf '\n\r')"
-#{{{ file loop
-for file in $files; do
-    IFS=$IFS_
-    fileIter=$((fileIter+1))
-    _filePos=$(filePos "$fileIter" "$num_files")
-    if ! isMatroska "$file"; then
-        log_notice "'$file' is not a matroska file $_filePos."
-        continue
-    fi
-
-    ffmpegOut=$("$FFMPEG" -nostdin -hide_banner -i "$file" 2>&1)
-    if [ "$FORCE" != true ] && [ "$VERIFY" = true ] && match_ere "$VERIFY_CHECK" "$ffmpegOut"; then
-        log_notice "Skipping, replaygain tags already exist on file '$file' $_filePos."
-        continue
-    fi
-
+#{{{ tag_tracks ( )  # Calculate RG and tag file
+tag_tracks ( ) {
+    file="$1"
     tracks=$(ffprobe -v error -of default=nw=1:nk=1 -select_streams a -show_entries stream=index "$file")
 
     #{{{ track loop
@@ -428,6 +364,78 @@ for file in $files; do
         tracksProcessed=$((tracksProcessed+1))
     done; [ $tracksProcessed -gt 0 ] && filesProcessed=$(( filesProcessed + 1 ))
     #}}} track loop
+}
+#}}} tag_tracks ( )
+
+#{{{ filePos ( )  # Show progress
+filePos ( ) {
+    fileIter=$1
+    num_files=$2
+    ! isint "$fileIter" || ! isint "$num_files" && return 1;
+    echo "(file $fileIter of $num_files, $(awk "BEGIN{print 100*($fileIter/$num_files)}")%)"
+}
+#}}} filePos ( )
+
+#{{{ Remux files
+if [ "$PREVIEW" = false ] && [ "$REMUX" = true ]; then
+    REGEX="(^.*)\.(asf|avi|flv|m4[pv]|mp[4g]|mov|mpeg|m2?ts|ogv|qt|ts|vob|webm|wmv)$"
+    files=$(find "$@" -type f -size "$MINSIZE" -regextype posix-extended -iregex "$REGEX")
+    num_files=$(echo "$files" | wc -l)
+    fileIter=0
+    IFS_=$IFS
+    # newline as IFS
+    IFS="$(printf '\n\r')"
+    for muxInFile in $files; do
+	IFS=$IFS_
+	fileIter=$((fileIter+1))
+	_filePos=$(filePos "$fileIter" "$num_files")
+	isMatroska "$muxInFile" && continue
+	muxOutFile=${muxInFile%.*}.mkv
+        if [ -e "$muxOutFile" ]; then
+            unset muxInFile muxOutFile
+            continue
+        fi
+        log_info "Remuxing '$muxInFile' to '$muxOutFile' $_filePos."
+        if "$FFMPEG" -n -loglevel error -stats -nostdin -hide_banner -i "$muxInFile" -c copy -map 0 "$muxOutFile"; then
+            rm "$muxInFile"
+	    tag_tracks "$muxOutFile"
+        else
+	    log_error "Something went wrong while muxing $muxOutFile, deleting."
+            rm "$muxOutFile"
+        fi
+        unset muxInFile muxOutFile
+    done
+    unset REGEX files fileIter
+fi
+#}}} Remux files
+
+#{{{ Main action: Calculating gain and tagging files
+VERIFY_CHECK="${REPLAYGAIN_ALGORITHM}: ${FFMPEGFILTER}"
+filesProcessed=0
+# FIXME: if there were non-mkv files in $@ find will throw an error because they got remuxed
+files=$(find "$@" -type f -size "$MINSIZE" \( -iname "*.mk[av]" -o -iname "*.mk3d" \))
+num_files=$(printf '%s\n' "$files" | wc -l)
+fileIter=0
+IFS_=$IFS
+# newline as IFS
+IFS="$(printf '\n\r')"
+#{{{ file loop
+for file in $files; do
+    IFS=$IFS_
+    fileIter=$((fileIter+1))
+    _filePos=$(filePos "$fileIter" "$num_files")
+    if ! isMatroska "$file"; then
+        log_notice "'$file' is not a matroska file $_filePos."
+        continue
+    fi
+
+    ffmpegOut=$("$FFMPEG" -nostdin -hide_banner -i "$file" 2>&1)
+    if [ "$FORCE" != true ] && [ "$VERIFY" = true ] && match_ere "$VERIFY_CHECK" "$ffmpegOut"; then
+        log_notice "Skipping, replaygain tags already exist on file '$file' $_filePos."
+        continue
+    fi
+
+    tag_tracks "$file"
 done
 #}}} file loop
 #}}} Main action: Calculating gain and tagging files

--- a/mkvrg
+++ b/mkvrg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 cat > /dev/null <<LICENSE
     Copyright (C) 2016,2023  kevinlekiller
     Copyright (C) 2016  WhitePeter
@@ -115,9 +115,6 @@ PREVIEW=${PREVIEW:-false}
 #########################################################################################
 ################################### ENV VARS End ########################################
 #########################################################################################
-
-# force number handling to C
-LC_NUMERIC=C
 
 # for more convenient regex construction
 FLOAT_ERE='[+-]?[0-9]+\.[0-9]+'

--- a/mkvrg
+++ b/mkvrg
@@ -122,6 +122,14 @@ LC_NUMERIC=C
 # for more convenient regex construction
 FLOAT_ERE='[+-]?[0-9]+\.[0-9]+'
 
+log_info () {
+    printf "INFO: %s\n" "$@" >&2
+}
+
+log_warn() {
+    printf "\e[93mWARNING: %s\e[0m\n" "$@" >&2
+}
+
 log_error() {
     printf "\e[31mERROR: %s\e[0m\n" "$@" >&2
 }
@@ -238,7 +246,7 @@ if [[ $PREVIEW == false && $REMUX == true ]]; then
             unset muxInFile muxOutFile
             continue
         fi
-        echo "INFO: Remuxing '$muxInFile' to '$muxOutFile' $(filePos)."
+        log_info "Remuxing '$muxInFile' to '$muxOutFile' $(filePos)."
         if "$FFMPEG" -n -loglevel error -stats -nostdin -hide_banner -i "$muxInFile" -c copy -map 0 "$muxOutFile"; then
             rm -f "$muxInFile"
         else
@@ -268,7 +276,7 @@ for file in "${files[@]}"; do
 
     tracksProcessed=0
     for track in $tracks; do
-        echo "INFO: Running ffmpeg using filter ${FFMPEGFILTER}, this can take a while. (track $track on file '$file') $(filePos) (REFLOUDNESS = $REFLOUDNESS LUFS)"
+        log_info "Running ffmpeg using filter ${FFMPEGFILTER}, this can take a while. (track $track on file '$file') $(filePos) (REFLOUDNESS = $REFLOUDNESS LUFS)"
         ffmpegCmd="$FFMPEG -loglevel info -nostats -nostdin -hide_banner -i \"$file\" -map 0:$track -filter:a \""
         if [[ $FFMPEGFILTER == "ebur128" ]]; then
             ffmpegCmd="${ffmpegCmd}ebur128=peak=$PEAKTYPE:framelog=quiet\" -f null -"
@@ -299,9 +307,9 @@ for file in "${files[@]}"; do
             echo -e "\e[92mNOTICE: Problem finding $FFMPEGFILTER info from ffmpeg for track $track on file '$file' $(filePos).\e[0m"
             continue
         fi
-        echo "INFO: Found: Gain ($trackGain dB | $(dBToLufs "$trackGain") LUFS), peak ($trackPeak amplitude | $(amplitudeToDB "$trackPeak") dB) for track $track on file '$file' $(filePos)."
+        log_info "Found: Gain ($trackGain dB | $(dBToLufs "$trackGain") LUFS), peak ($trackPeak amplitude | $(amplitudeToDB "$trackPeak") dB) for track $track on file '$file' $(filePos)."
         if [[ $PREVIEW == true ]]; then
-            echo "INFO: PREVIEW mode is on, not applying tags, skipping to next track/file."
+            log_info "PREVIEW mode is on, not applying tags, skipping to next track/file."
             continue
         fi
 
@@ -342,10 +350,10 @@ for file in "${files[@]}"; do
         sed -i "/^[[:space:]]*$/d" "$tmpFile"
         mkvpropedit --tags track:"$((track+1))":"$tmpFile" "$file"
         if [[ $VERIFY == true ]] && [[ ! $("$FFMPEG" -nostdin -hide_banner -i "$file" 2>&1) =~ $VERIFY_CHECK ]]; then
-            echo -e "\e[93mWARNING: Replaygain has not been applied for track $track on file '$file' $(filePos).\e[0m"
+            log_warn "Replaygain has not been applied for track $track on file '$file' $(filePos)."
             continue
         fi
-        echo "INFO: Succesfully applied replaygain tags for track $track on file '$file' $(filePos)."
+        log_info "Succesfully applied replaygain tags for track $track on file '$file' $(filePos)."
         ((tracksProcessed++))
     done
     [[ $tracksProcessed -gt 0 ]] && ((filesProcessed++))

--- a/mkvrg
+++ b/mkvrg
@@ -122,16 +122,51 @@ LC_NUMERIC=C
 # for more convenient regex construction
 FLOAT_ERE='[+-]?[0-9]+\.[0-9]+'
 
+log_message () {
+    level=$1
+    case $level in
+	error)
+	    color='\e[31m'
+	    prefix='ERROR'
+	    shift
+	    ;;
+	warn|warning)
+	    color='\e[93m'
+	    prefix='WARNING'
+	    shift
+	    ;;
+	notice)
+	    color='\e[92m'
+	    prefix='NOTICE'
+	    shift
+	    ;;
+	info)
+	    color='\e[0m'
+	    prefix='INFO'
+	    shift
+	    ;;
+	*)
+	    color='\e[0m'
+	    prefix='INFO'
+	    ;;
+    esac
+    text="$*"
+    printf '%b%s\e[0m\n' "$color" "$prefix: $text" >&2
+}
+
+log_error () {
+    log_message error "$@"
+}
+
+log_warn () {
+    log_message warn "$@"
+}
+log_notice () {
+    log_message notice "$@"
+}
+
 log_info () {
-    printf "INFO: %s\n" "$@" >&2
-}
-
-log_warn() {
-    printf "\e[93mWARNING: %s\e[0m\n" "$@" >&2
-}
-
-log_error() {
-    printf "\e[31mERROR: %s\e[0m\n" "$@" >&2
+    log_message info "$@"
 }
 
 match_ere () { # match string against extended reqex

--- a/mkvrg
+++ b/mkvrg
@@ -18,8 +18,10 @@ cat > /dev/null <<LICENSE
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
 LICENSE
+
 reqProgs="awk ffmpeg ffprobe file find grep mkvpropedit mktemp sed"
-read -rd '' DESCRIPTION <<DESCRIPTION
+[ "$1" = "--help" ] || [ "$1" = "-h" ] &&
+    { cat; exit; } <<DESCRIPTION
     mkvrg - Apply replaygain tags to matroska files without remuxing (gain is calculated using ffmpeg and tags are applied using mkvpropedit).
 
     Bash script for analyzing audio tracks in matroska files with ffmpeg and
@@ -120,11 +122,6 @@ LC_NUMERIC=C
 # for more convenient regex construction
 FLOAT_ERE='[+-]?[0-9]+\.[0-9]+'
 
-if [[ $1 == "--help" || $1 == "-h" ]]; then
-    echo "$DESCRIPTION"
-    exit 0
-fi
-unset DESCRIPTION
 
 if [[ ! $FFMPEGFILTER =~ ^(ebur128|loudnorm|replaygain)$ ]]; then
     echo -e "\e[31mERROR: Invalid FFMPEGFILTER.\e[0m" > /dev/stderr

--- a/mkvrg
+++ b/mkvrg
@@ -256,9 +256,11 @@ if [ "$PREVIEW" = false ] && [ "$REMUX" = true ]; then
     files=$(find "$@" -type f -size "$MINSIZE" -regextype posix-extended -iregex "$REGEX")
     num_files=$(echo "$files" | wc -l)
     fileIter=0
-    [ -n "${IFS+set}" ] && IFS_=$IFS
+    IFS_=$IFS
+    # newline as IFS
+    IFS="$(printf '\n\r')"
     for muxInFile in $files; do
-	[ -n "${IFS_+set}" ] && IFS=$IFS_
+	IFS=$IFS_
 	fileIter=$((fileIter+1))
 	_filePos=$(filePos "$fileIter" "$num_files")
 	isMatroska "$muxInFile" && continue
@@ -279,10 +281,13 @@ if [ "$PREVIEW" = false ] && [ "$REMUX" = true ]; then
 fi
 
 filesProcessed=0
+# FIXME: if there were non-mkv files in $@ find will throw an error because they got remuxed
 files=$(find "$@" -type f -size "$MINSIZE" \( -iname "*.mk[av]" -o -iname "*.mk3d" \))
 num_files=$(printf '%s\n' "$files" | wc -l)
 fileIter=0
-[ -n "${IFS+set}" ] && IFS_=$IFS
+IFS_=$IFS
+# newline as IFS
+IFS="$(printf '\n\r')"
 for file in $files; do
     IFS=$IFS_
     fileIter=$((fileIter+1))
@@ -375,6 +380,7 @@ for file in $files; do
         sed -i "s/^            //g" "$tmpFile"
         sed -i "/^[[:space:]]*$/d" "$tmpFile"
         mkvpropedit --tags track:"$((track+1))":"$tmpFile" "$file"
+	# FIXME: Needs actual check of values
         if [ "$VERIFY" = true ] && ! match_ere "$VERIFY_CHECK" "$("$FFMPEG" -nostdin -hide_banner -i "$file" 2>&1)"; then
             log_warn "Replaygain has not been applied for track $track on file '$file' $_filePos."
             continue


### PR DESCRIPTION
This is an attempt at getting rid of all bashisms to make mkvrg more portable by being pure POSIX sh. While I was looking at the script after being AWOL for a long time, I felt that some refactoring was in order to reduce clutter. I also don't like to rely on bash too much, as a matter of taste an style.

A further goal, which might warrant another branch, is to actually get rid of the handling of more than one file, because I find it unnecessary. I think it would be better to simplify the script and leverage OS utilities to do the "bigger picture" stuff. For instance there is GNU parallel, with which one can get multi-process execution, whereas this script is strictly sequential and can only do one track of one file at a time. Plus, bash and zsh have very powerful file name glob expressions, which makes the "recursive" mode superfluous.

Let me say it with this example, which uses zsh and parallel:
```zsh
parallel -k mkvrg ::: **/*.mkv
```
For the uninitiated, `**` (which also works in bash, as I have been told) is a convenient shortcut to similar functionality of `find`:
```zsh
# same as above only with find
parallel -k mkvrg ::: $(find -iname '*.mkv')
```

I really think less is more, given the power of the Linux/Unix envrionment. "Do one thing and do it well", and glue together robust one-trick ponies to achieve your goal.

So, what do you think?

P.S.: Case in point, the handling of multiple files is the one thing that stands in the way of being pure POSIX sh, since it relies on arrays, which are an extension beyond POSIX.